### PR TITLE
Added 235 and 814 api code

### DIFF
--- a/amino/lib/util/exceptions.py
+++ b/amino/lib/util/exceptions.py
@@ -196,6 +196,15 @@ class UserNotMemberOfCommunity(Exception):
     def __init__(*args, **kwargs):
         Exception.__init__(*args, **kwargs)
 
+class RequestRejected(Exception):
+    """
+    - **API Code** : 235
+    - **API Message** : Request rejected. You have been temporarily muted (read only mode) because you have received a strike. To learn more, please check the Help Center.
+    - **API String** : ``Unknown String``
+    """
+    def __init__(*args, **kwargs):
+        Exception.__init__(*args, **kwargs)
+
 class ActivateAccount(Exception):
     """
     - **API Code** : 238
@@ -390,6 +399,15 @@ class CommunityCreateLimitReached(Exception):
     - **API Code** : 806
     - **API Message** : ``Unknown Message``
     - **API String** : API_ERR_COMMUNITY_USER_CREATED_COMMUNITIES_EXCEED_QUOTA
+    """
+    def __init__(*args, **kwargs):
+        Exception.__init__(*args, **kwargs)
+
+class CommunityDisabled(Exception):
+    """
+    - **API Code** : 814
+    - **API Message** : This Community is disabled.
+    - **API String** : ``Unknown String``
     """
     def __init__(*args, **kwargs):
         Exception.__init__(*args, **kwargs)
@@ -796,6 +814,7 @@ def CheckException(data):
     elif api_code == 225: raise UserUnavailable(data)
     elif api_code == 229: raise YouAreBanned(data)
     elif api_code == 230: raise UserNotMemberOfCommunity(data)
+    elif api_code == 235: raise RequestRejected(data)
     elif api_code == 238: raise ActivateAccount(data)
     elif api_code == 239: raise CantLeaveCommunity(data)
     elif api_code == 240: raise ReachedTitleLength(data)
@@ -818,6 +837,7 @@ def CheckException(data):
     elif api_code == 802: raise InvalidCodeOrLink(data)
     elif api_code == 805: raise CommunityNameAlreadyTaken(data)
     elif api_code == 806: raise CommunityCreateLimitReached(data)
+    elif api_code == 814: raise CommunityDisabled(data)
     elif api_code == 833: raise CommunityDeleted(data)
     elif api_code == 1501: raise DuplicatePollOption(data)
     elif api_code == 1507: raise ReachedMaxPollOptions(data)


### PR DESCRIPTION
given for nsfw pictures - {'api:message': 'Request rejected. You have been temporarily muted (read only mode) because you have received a strike. To learn more, please check the Help Center.',
'api:statuscode': 235}

given if a disabled community is requested - {'api:message': 'This Community is disabled.' 'api:statuscode': 814}