### PR TITLE
Add ReachedMaxCategories Exception

### DIFF
--- a/amino/lib/util/exceptions.py
+++ b/amino/lib/util/exceptions.py
@@ -430,6 +430,15 @@ class CommunityDeleted(Exception):
     def __init__(*args, **kwargs):
         Exception.__init__(*args, **kwargs)
 
+class ReachedMaxCategories(Exception):
+    """
+    - **API Code** : 1002
+    - **API Message** : Sorry, you can create up to 100 categories.
+    - **API String** : ``Unknown String``
+    """
+    def __init__(*args, **kwargs):
+        Exception.__init__(*args, **kwargs)
+
 class DuplicatePollOption(Exception):
     """
     - **API Code** : 1501


### PR DESCRIPTION
This exception should be raised when the API gives the status code `1002` when attempting to create a blog category.