### PR TITLE
Remove duplicated item from get_chat_messages 

### DIFF
--- a/docs/amino.html
+++ b/docs/amino.html
@@ -695,7 +695,7 @@
 <dt><strong>Parameters</strong></dt><dd><ul class="simple">
 <li><p><strong>chatId</strong> : ID of the Chat.</p></li>
 <li><p><em>size</em> : Size of the list.</p></li>
-<li><p><em>size</em> : Size of the list.</p></li>
+
 <li><p><em>pageToken</em> : Next Page Token.</p></li>
 </ul>
 </dd>


### PR DESCRIPTION
get_chat_messages has the size parameter listed twice in the documentation, despite only needing the parameter once. 