### PR TITLE
Update socket version. (fix AttributeError)

### DIFF
--- a/amino/socket.py
+++ b/amino/socket.py
@@ -44,11 +44,11 @@ class SocketHandler:
                 self.close()
                 self.run_amino_socket()
 
-    def on_open(self):
+    def on_open(self, **kwargs):
         if self.debug is True:
             print("[socket][on_open] Socket Opened")
 
-    def on_close(self):
+    def on_close(self, **kwargs):
         if self.debug is True:
             print("[socket][on_close] Socket Closed")
 
@@ -66,7 +66,7 @@ class SocketHandler:
 
         contextlib.suppress(self.socket.sock.pong(data))
 
-    def handle_message(self, data):
+    def handle_message(self, ws, data):
         self.client.handle_socket_message(data)
         return
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "requests",
         "six",
         "websockets",
-        "websocket-client==0.57.0",
+        "websocket-client==1.3.1",
         "aiohttp"
     ],
     setup_requires = [


### PR DESCRIPTION
The amino.py library, because of an old version of websocket-client(0.57.0), has long had an issue that sometimes causes the "AttributeError: 'Thread' object has no attribute 'isAlive'" error, so I updated this to 1.3.1 to make this error go away.